### PR TITLE
Disable insecure audit checks in Composer configuration.

### DIFF
--- a/shop/b-7.0.x-ee-smarty-dev/run.sh
+++ b/shop/b-7.0.x-ee-smarty-dev/run.sh
@@ -45,6 +45,7 @@ make up
 # Update composer to 2.4+
 docker compose exec php sudo composer self-update --2
 
+docker compose exec php composer config audit.block-insecure false
 docker compose exec php composer config github-protocols https
 docker compose exec php composer config repositories.oxid-esales/oxideshop-ee git https://github.com/OXID-eSales/oxideshop_ee.git
 docker compose exec php composer config repositories.oxid-esales/oxideshop-pe git https://github.com/OXID-eSales/oxideshop_pe.git


### PR DESCRIPTION
Problem 1
    - Root composer.json requires oxid-esales/oxideshop-unified-namespace-generator dev-b-7.0.x -> satisfiable by oxid-esales/oxideshop-unified-namespace-generator[dev-b-7.0.x].
    - oxid-esales/oxideshop-unified-namespace-generator dev-b-7.0.x requires smarty/smarty ^v2.6.30 -> found smarty/smarty[v2.6.30, v2.6.31, v2.6.33] but these were not loaded, because they are affected by security advisories. To ignore the advisories, add ("PKSA-28zg-9h7g-fhvp", "PKSA-54c6-f9b9-7wg4", "PKSA-wy1k-8qg5-z8xd", "PKSA-yr6f-z9sx-cps3", "PKSA-2q9d-8kh9-49wx", "PKSA-pght-23ww-rrdy", "PKSA-6y8p-nrf4-ysf5", "PKSA-98zc-53yc-qt81", "PKSA-31hv-m6rg-8ryk", "PKSA-wc9h-gs49-76tm", "PKSA-t4kv-1sv2-1mzx", "PKSA-thph-wfk6-pp4j", "PKSA-hgp5-21g7-7phg") to the audit "ignore" config. **To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.**