### PR TITLE
Pin PHP 8.4 in the 8.0 recipe

### DIFF
--- a/shop/b-8.0.x-components.sh
+++ b/shop/b-8.0.x-components.sh
@@ -31,7 +31,7 @@ perl -pi\
   containers/httpd/project.conf
 
 perl -pi\
-  -e 's#PHP_VERSION=.*#PHP_VERSION=8.2#g;'\
+  -e 's#PHP_VERSION=.*#PHP_VERSION=8.4#g;'\
   .env
 
 mkdir source


### PR DESCRIPTION
## Problem

`shop/b-8.0.x-components.sh` pins `PHP_VERSION=8.2`, but `oxid-esales/oxideshop-ce` on `b-8.0.x` requires `php ^8.4`:

```json
"require": {
    "php": "^8.4",
```

So `composer update` aborts:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires oxid-esales/oxideshop-ce dev-b-8.0.x -> satisfiable by oxid-esales/oxideshop-ce[dev-b-8.0.x].
    - oxid-esales/oxideshop-ce dev-b-8.0.x requires php ^8.4 -> your php version (8.2.33) does not satisfy that requirement.
  Problem 2
    - Root composer.json requires oxid-esales/twig-component dev-b-8.0.x -> satisfiable by oxid-esales/twig-component[dev-b-8.0.x].
    - oxid-esales/twig-component dev-b-8.0.x requires php >=8.4 -> your php version (8.2.33) does not satisfy that requirement.
```

The recipe does not stop there. It goes on to the console commands, which fail because `vendor/` was never written:

```
OCI runtime exec failed: exec failed: unable to start container process: exec: "vendor/bin/oe-console": stat vendor/bin/oe-console: no such file or directory
```

That message appears four times, once for `oe:database:reset`, `oe:setup:demodata`, `oe:theme:activate` and `oe:admin:create`. The recipe still exits 0, so the result is an instance without dependencies and without a database, and nothing says so.

## Change

One line: pin `PHP_VERSION=8.4` instead of `8.2`.

## Checked

Raising the pin to 8.4 and running the recipe steps: composer resolves, all four `oe-console` commands report `[OK]`, the shop answers `HTTP 200` and `ShopVersion::getVersion()` returns `8.0.0-alpha.3`. Environment: macOS, Docker 29.6.1, image `oxidesales/oxideshop-docker-php:8.4` (PHP 8.4.23), MySQL 8.4.
