### PR TITLE
Pin MySQL 5.7 in the 6.5 recipe

### DIFF
--- a/shop/b-6.5.x-ce-dev/run.sh
+++ b/shop/b-6.5.x-ce-dev/run.sh
@@ -17,6 +17,13 @@ perl -pi\
   -e 's#/var/www/#/var/www/source/#g;'\
   containers/httpd/project.conf
 
+# 6.5 stores encrypted config values with the MySQL ENCODE()/DECODE() functions,
+# which MySQL removed in 8.0. With the SDK default (8.4) the shop installer dies
+# with "FUNCTION example.DECODE does not exist".
+perl -pi\
+  -e 's#MYSQL_VERSION=.*#MYSQL_VERSION=5.7#g;'\
+  .env
+
 # Configure shop
 cp source/source/config.inc.php.dist source/source/config.inc.php
 


### PR DESCRIPTION
## Problem

`shop/b-6.5.x-ce-dev/run.sh` pins no database version, so it inherits the SDK default from `.env.dist`, currently `MYSQL_VERSION=8.4`.

6.5 stores encrypted configuration values with the MySQL `ENCODE()` / `DECODE()` functions, which MySQL removed in 8.0. `vendor/bin/reset-shop` therefore dies:

```
Exception: SQLSTATE[42000]: Syntax error or access violation: 1305
FUNCTION example.DECODE does not exist
in /var/www/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/...
#41 .../ServiceCaller.php(88): callLocalService('ShopInstaller')
#42 .../bin/reset-shop(25): callService('ShopInstaller')
```

The recipe still ends with `Done!`. What remains is a shop that answers `HTTP 500`, with one row in `oxuser` and none in `oxarticles`.

## Change

Pin `MYSQL_VERSION=5.7` after `make setup`, in the same style the recipe already uses for `containers/httpd/project.conf`.

## Checked

With 5.7 the recipe runs through: `reset-shop` completes, the shop answers `HTTP 200` with 102733 bytes, `oxarticles` holds 217 rows, `ShopVersion::getVersion()` returns `6.5.5`. Environment: macOS, Docker 29.6.1, PHP image 8.4, database image `oxidesales/oxideshop-docker-database:5.7`.

Note for anyone reproducing this: 6.5 also needs `smarty/smarty` 2.6, which Composer refuses because of its advisories. That is a separate decision and not part of this change.
